### PR TITLE
Add an example of creating a Policy through the provider.

### DIFF
--- a/7_managing_policies/README.md
+++ b/7_managing_policies/README.md
@@ -1,0 +1,3 @@
+# Managing Policies
+
+A collection of examples regarding managing Policies.

--- a/7_managing_policies/init.tf
+++ b/7_managing_policies/init.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    sdm = {
+      version = "~> 11.3.0"
+      source  = "strongdm/sdm"
+    }
+  }
+}

--- a/7_managing_policies/policies.tf
+++ b/7_managing_policies/policies.tf
@@ -1,0 +1,28 @@
+# Copyright 2024 strongDM Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Creates a Policy that forbids all principals from connecting to it.
+resource "sdm_policy" "forbid_the_bad_connect" {
+  name = "forbid-the-bad-resource"
+  description = "Forbid connecting to the bad resource."
+
+  policy = <<EOP
+forbid (
+     principal,
+     action == StrongDM::Action::"connect",
+     resource == StrongDM::Resource::"rs-123d456789"
+);
+EOP
+}


### PR DESCRIPTION
This adds an example that make use of the Policies resource the provider, 11.3.0 and later. This example is derived from the Policies examples  in [strongdm-sdk-go-examples](https://github.com/strongdm/strongdm-sdk-go-examples/tree/master/8_policies).

A plan, apply, edit, plan, apply, remove, apply was performed, testing full CRUD management through the provider.