### PR TITLE
Eng-2653 Examples for Manager Approvals For Approval Workflows 

### DIFF
--- a/6_managing_approval_workflows/create_manual_approval_workflow.tf
+++ b/6_managing_approval_workflows/create_manual_approval_workflow.tf
@@ -21,6 +21,7 @@
 # - skip_after specifies a timeout after which the approval step will be auto-approved
 # - roles designated as approvers in each approval step allow users in that role to grant approval for that approval step
 # - users designated as approvers in each approval step allows that user to grant approval for that approval step
+# - reference can be used to designate either the manager or the manager of the manager of the requester as an approver for that approval step
 resource "sdm_approval_workflow" "manual_approval_workflow" {
     name = "manual approval workflow example"
     approval_mode = "manual"
@@ -29,6 +30,9 @@ resource "sdm_approval_workflow" "manual_approval_workflow" {
         skip_after = "1h0m0s"
         approvers {
             account_id = sdm_account.approver_user_manual_workflow.id
+        }
+        approvers {
+            reference = "manager-of-requester"
         }
     }
     approval_step {
@@ -39,6 +43,9 @@ resource "sdm_approval_workflow" "manual_approval_workflow" {
         }
         approvers {
             account_id = sdm_account.approver2_user_manual_workflow.id
+        }
+        approvers {
+            reference = "manager-of-manager-of-requester"
         }
     }
 }

--- a/6_managing_approval_workflows/init.tf
+++ b/6_managing_approval_workflows/init.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     sdm = {
-      version = "~> 14.2"
+      version = "~> 14.6"
       source  = "strongdm/sdm"
     }
   }


### PR DESCRIPTION
Addresses ENG-2653
We introduce the ability to specify the "manager-of-requester" or "manager-of-manager-of-requester" as an approver for approval workflows and update the examples to reflect that.

# QA
We ran the SDK examples against blue origin and validate the the correct approval workflow configuration was created.